### PR TITLE
oppa-lana-style uses the prompt callback function to inject generic strings

### DIFF
--- a/oppa-lana-style.zsh-theme
+++ b/oppa-lana-style.zsh-theme
@@ -1,5 +1,7 @@
 : ${omg_ungit_prompt:=$PS1}
+
 : ${omg_second_line:="%~ • "}
+
 : ${omg_is_a_git_repo_symbol:=''}
 : ${omg_has_untracked_files_symbol:=''}        #                ?    
 : ${omg_has_adds_symbol:=''}
@@ -132,11 +134,23 @@ function custom_build_prompt {
             fi
         fi
         prompt+=$(enrich_append ${is_on_a_tag} "${omg_is_on_a_tag_symbol} ${tag_at_current_commit}" "${black_on_red}")
-        prompt+="%k%F{red}%k%f
-${omg_second_line}"
+        prompt+="%k%F{red}%k%f\n"
+        prompt+="$(eval_second_line_if_present)"
+        prompt+="${omg_second_line}"
     else
-        prompt="${omg_ungit_prompt}"
+        prompt+="$(eval_second_line_if_present)"
+        prompt+="${omg_ungit_prompt}"
     fi
  
     echo "${prompt}"
 }
+
+function_exists() {
+    declare -f -F $1 > /dev/null
+    return $?
+}
+
+function eval_second_line_if_present {
+        function_exists omg_prompt_callback && echo "$(omg_prompt_callback)"
+}
+

--- a/oppa-lana-style.zsh-theme
+++ b/oppa-lana-style.zsh-theme
@@ -135,22 +135,12 @@ function custom_build_prompt {
         fi
         prompt+=$(enrich_append ${is_on_a_tag} "${omg_is_on_a_tag_symbol} ${tag_at_current_commit}" "${black_on_red}")
         prompt+="%k%F{red}%k%f\n"
-        prompt+="$(eval_second_line_if_present)"
+        prompt+="$(eval_prompt_callback_if_present)"
         prompt+="${omg_second_line}"
     else
-        prompt+="$(eval_second_line_if_present)"
+        prompt+="$(eval_prompt_callback_if_present)"
         prompt+="${omg_ungit_prompt}"
     fi
  
     echo "${prompt}"
 }
-
-function_exists() {
-    declare -f -F $1 > /dev/null
-    return $?
-}
-
-function eval_second_line_if_present {
-        function_exists omg_prompt_callback && echo "$(omg_prompt_callback)"
-}
-


### PR DESCRIPTION
This PL is aimed to solve the issue #38. It depends on the PL https://github.com/arialdomartini/oh-my-git/pull/40 of oh-my-git, since it relies on two functions defined in `base.sh`

This PL makes the oppa-lana-style theme use the prompt callback function `omg_prompt_callback`, which can be used to define a generic segment to be displayed in the second line of the prompt.

Please, refer to the documentation in https://github.com/arialdomartini/oh-my-git/pull/40

Since colors in zsh are managed slightly differently than in bash, the callback function aimed to inject the virtualenv name is also a bit different. The following snipped can be used in `.zshrc`

``` shell
VIRTUAL_ENV_DISABLE_PROMPT=true
function omg_prompt_callback() {
    if [ -n "${VIRTUAL_ENV}" ]; then
        echo "%F{white}(`basename ${VIRTUAL_ENV}`)%f "
    fi
}
```

When inside a virtualenv, this results in the prompt

![screen shot 2015-01-22 at 09 32 03](https://cloud.githubusercontent.com/assets/150719/5852589/91738272-a219-11e4-888e-8b8d9833f5f0.png)

rather that the prompt

![screen shot 2015-01-22 at 08 57 08](https://cloud.githubusercontent.com/assets/150719/5852434/06933e88-a217-11e4-81a0-153c5a300b0a.png)
