### PR TITLE
Fix enrich_append args

### DIFF
--- a/oppa-lana-style.zsh-theme
+++ b/oppa-lana-style.zsh-theme
@@ -27,8 +27,8 @@ RPROMPT='%{$reset_color%}%T %{$fg_bold[white]%} %n@%m%{$reset_color%}'
 
 function enrich_append {
     local flag=$1
-    local symbol=$2
-    local color=${3:-$omg_default_color_on}
+    local symbol="$2"
+    local color="${3:-$omg_default_color_on}"
     if [[ $flag == false ]]; then symbol=' '; fi
 
     echo -n "${color}${symbol}  "


### PR DESCRIPTION
![error](https://leto5d.storage.yandex.net/rdisk/b17f435485b72a93ef1d5cac22b4c2d287dc953920854d119fb87e2a2208038b/inf/N4AZhcXL0cF74XE2n-oMOXON6Dgw0IfIxfdcJhxrJ7SUS9iuhP8DVNKr_VkFv03t6bCI9nMyjqZJCpioYreUIA==?uid=0&filename=2015-11-12%2003-30-55%201.%20baymer%4084%3A%20~%20dev%20islands%20%28zsh%29.png&disposition=inline&hash=&limit=0&content_type=image%2Fpng&tknv=v2&rtoken=3f322281923b5fdd8f1c299c3d08d7a0&force_default=no&ycrid=na-52ba1096beb6d3fe2b9d9b0f042586bf-downloader14e)

env:
- MacOS: Yosimite
- zsh: 5.0.5
- iterm: 2.1.4
- antigen: latest
